### PR TITLE
[회원정보 Activity & 맵 fragment 리펙토링 작업] 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -184,4 +184,4 @@ fabric.properties
 
 !/gradle/wrapper/gradle-wrapper.jar
 
-# End of https://www.toptal.com/developers/gitignore/api/kotlin,android,androidstudio
+# End of https://www.toptal.com/developers/gitignore/api/kotlin,android,androidstudio.DS_Store

--- a/app/src/main/java/com/pet/frompet/data/model/UserLocationInfo.kt
+++ b/app/src/main/java/com/pet/frompet/data/model/UserLocationInfo.kt
@@ -1,0 +1,6 @@
+package com.pet.frompet.data.model
+
+data class UserLocationInfo(
+    val userUid : List<String> = emptyList(),
+    val userLocations : List<UserLocation> = emptyList()
+)

--- a/app/src/main/java/com/pet/frompet/data/repository/category/CategoryRepositoryImp.kt
+++ b/app/src/main/java/com/pet/frompet/data/repository/category/CategoryRepositoryImp.kt
@@ -42,7 +42,6 @@ class CategoryRepositoryImp(
                 .orderBy("timestamp",Query.Direction.DESCENDING)
                 .get()
                 .await()
-            Log.e("sshImp", "$petType")
             for (document in querySnapshot.documents) {
                 val title = document.getString("title") ?: ""
                 val tag = document.getString("tag") ?: ""

--- a/app/src/main/java/com/pet/frompet/data/repository/map/MapRepository.kt
+++ b/app/src/main/java/com/pet/frompet/data/repository/map/MapRepository.kt
@@ -1,12 +1,16 @@
 package com.pet.frompet.data.repository.map
 
+import com.naver.maps.geometry.LatLngBounds
 import com.pet.frompet.data.model.UserLocation
+import com.pet.frompet.data.model.UserLocationInfo
+
 
 interface MapRepository {
 
-//      suspend fun getCommunityData(petType:String): List<CommunityData>
-      suspend fun getUserLocation() : List<UserLocation>
-
-
+      suspend fun getCurrentUserId():String
+      suspend fun getUserLocation(): UserLocation
+      suspend fun updateUserLocation(userLocation: UserLocation)
+      suspend fun getOtherUserLocation():List<UserLocation>
+      suspend fun getloadLocationData(bounds: LatLngBounds): UserLocationInfo
 
 }

--- a/app/src/main/java/com/pet/frompet/data/repository/map/MapRepositoryImpl.kt
+++ b/app/src/main/java/com/pet/frompet/data/repository/map/MapRepositoryImpl.kt
@@ -1,11 +1,93 @@
 package com.pet.frompet.data.repository.map
 
+import android.util.Log
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.database.FirebaseDatabase
+import com.google.firebase.firestore.FirebaseFirestore
+import com.naver.maps.geometry.LatLng
+import com.naver.maps.geometry.LatLngBounds
 import com.pet.frompet.data.model.UserLocation
-import com.pet.frompet.data.repository.map.MapRepository
+import com.pet.frompet.data.model.UserLocationInfo
+import com.pet.frompet.ui.map.MapViewModel
+import kotlinx.coroutines.tasks.await
+import kotlin.coroutines.resume
+import kotlin.coroutines.suspendCoroutine
 
-//class MapRepositoryImpl : MapRepository {
-//
-//    override suspend fun getLocation(): List<UserLocation> {
-//        TODO("Not yet implemented")
-//    }
-//}
+class MapRepositoryImpl(
+    private val firebaseDatabase: FirebaseDatabase,
+    private val firestore: FirebaseFirestore
+) : MapRepository {
+    private val locationRef = firebaseDatabase.getReference("location")
+    override suspend fun getCurrentUserId(): String {
+        return FirebaseAuth.getInstance().currentUser?.uid ?: ""
+    }
+
+    override suspend fun getUserLocation(): UserLocation {
+        val currentUserId = getCurrentUserId()
+        return firebaseDatabase.getReference("location")
+            .child(currentUserId)
+            .get()
+            .await()
+            .getValue(UserLocation::class.java)
+            ?: UserLocation()
+    }
+
+    override suspend fun updateUserLocation(userLocation: UserLocation) {
+        val currentUserId = getCurrentUserId()
+        firebaseDatabase.getReference("location")
+            .child(currentUserId)
+            .setValue(userLocation)
+            .await()
+    }
+
+    override suspend fun getOtherUserLocation(): List<UserLocation> {
+        val currentUserId = getCurrentUserId()
+        val snapshot = firebaseDatabase.getReference("location")
+            .get()
+            .await()
+
+        val otherUserLocations = mutableListOf<UserLocation>()
+        for (locationSnapshot in snapshot.children) {
+            val location = locationSnapshot.getValue(UserLocation::class.java)
+            val userUid = locationSnapshot.key
+
+            if (location != null && userUid != null && userUid != currentUserId) {
+                otherUserLocations.add(location)
+            }
+        }
+        return otherUserLocations
+    }
+
+    override suspend fun getloadLocationData(bounds: LatLngBounds): UserLocationInfo {
+        return suspendCoroutine { continuation ->
+            val userUids = mutableListOf<String>()
+            val locationList = mutableListOf<UserLocation>()
+
+            locationRef.get().addOnSuccessListener { snapshot ->
+                for (locationSnapshot in snapshot.children) {
+                    val location =
+                        locationSnapshot.getValue(UserLocation::class.java)
+                    if (location != null && bounds.contains(
+                            LatLng(
+                                location.latitude,
+                                location.longitude
+                            )
+                        )
+                    ) {
+                        Log.d("LoadLocationData", "유저 아이디: ${locationSnapshot.key}")
+                        // 지도 영역에 포함되는 위치만 처리
+                        // null 방지 위해 orEmpty()
+                        val userUid = locationSnapshot.key.orEmpty()
+                        userUids.add(userUid)
+
+                        // 위치 정보를 리스트에 추가
+                        locationList.add(UserLocation(location.latitude, location.longitude))
+                    }
+                }
+
+                val userLocationInfo = UserLocationInfo(userUids, locationList)
+                continuation.resume(userLocationInfo)
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pet/frompet/data/repository/memberinfo/MemberInfoRepository.kt
+++ b/app/src/main/java/com/pet/frompet/data/repository/memberinfo/MemberInfoRepository.kt
@@ -1,0 +1,8 @@
+package com.pet.frompet.data.repository.memberinfo
+
+import com.pet.frompet.data.model.CommunityHomeData
+
+interface MemberInfoRepository {
+
+    suspend fun getMemberSpinner(): List<CommunityHomeData>
+}

--- a/app/src/main/java/com/pet/frompet/data/repository/memberinfo/MemberInfoRepository.kt
+++ b/app/src/main/java/com/pet/frompet/data/repository/memberinfo/MemberInfoRepository.kt
@@ -1,8 +1,13 @@
 package com.pet.frompet.data.repository.memberinfo
 
 import com.pet.frompet.data.model.CommunityHomeData
+import com.pet.frompet.data.model.User
 
 interface MemberInfoRepository {
 
     suspend fun getMemberSpinner(): List<CommunityHomeData>
+
+    suspend fun uploadPetProfile(uri: String):String
+
+    suspend fun saveToFireStore(user: User): Result<Unit>
 }

--- a/app/src/main/java/com/pet/frompet/data/repository/memberinfo/MemberInfoRepositoryImp.kt
+++ b/app/src/main/java/com/pet/frompet/data/repository/memberinfo/MemberInfoRepositoryImp.kt
@@ -1,12 +1,28 @@
 package com.pet.frompet.data.repository.memberinfo
 
 import android.content.Context
+import android.net.Uri
+import android.provider.Settings.Global.getString
 import android.util.Log
+import com.bumptech.glide.Glide
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.storage.FirebaseStorage
 import com.pet.frompet.R
 import com.pet.frompet.data.model.CommunityHomeData
+import com.pet.frompet.data.model.User
+import com.pet.frompet.ui.login.putFile
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.tasks.await
+import java.lang.Exception
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.Locale
+import kotlin.coroutines.resumeWithException
 
 class MemberInfoRepositoryImp(
-    private val context: Context
+    private val context: Context,
+    private val storage: FirebaseStorage,
+    private val fireStore: FirebaseFirestore
 ):MemberInfoRepository {
     override suspend fun getMemberSpinner(): List<CommunityHomeData> {
         val categories = listOf(
@@ -28,6 +44,58 @@ class MemberInfoRepositoryImp(
             )
         }
     }
+
+    override suspend fun uploadPetProfile(uri: String): String {
+        return suspendCancellableCoroutine { continuation ->
+            uri?.let { petProfileUri ->
+                val timestamp = SimpleDateFormat(
+                    context.getString(R.string.member_info_timestamp),
+                    Locale.getDefault()
+                ).format(Date())
+                val fileName = "IMAGE_$timestamp.png"
+
+                val storageRef = storage.reference.child("images").child(fileName)
+
+                val uploadTask = storageRef.putFile(Uri.parse(petProfileUri))
+
+                uploadTask.continueWithTask { task ->
+                    if (!task.isSuccessful) {
+                        task.exception?.let { throw it }
+                    }
+                    storageRef.downloadUrl
+                }.addOnCompleteListener { task ->
+                    if (task.isSuccessful) {
+                        val downloadUri = task.result
+                        val imageUrl = downloadUri.toString()
+                        continuation.resume(imageUrl) {
+                            // 취소 시 추가 작업 수행
+                            uploadTask.cancel()
+                        }
+                    } else {
+                        continuation.resumeWithException(task.exception ?: IllegalStateException("업로드 실패"))
+                    }
+                }
+
+                uploadTask.addOnCanceledListener {
+                    // 업로드 취소 처리
+                    continuation.cancel()
+                }
+            } ?: continuation.resumeWithException(IllegalArgumentException("Uri가 null입니다"))
+        }
+    }
+
+    override suspend fun saveToFireStore(user: User): Result<Unit> {
+        return try{
+            FirebaseFirestore.getInstance().collection("User")
+                .document(user.uid)
+                .set(user)
+                .await()
+            Result.success(Unit)
+        }catch (e: Exception){
+            Result.failure(e)
+        }
+    }
+
 
     private fun getAnimalImage(categoryString: String): Int {
         val resourceName = categoryString.split("_").last()

--- a/app/src/main/java/com/pet/frompet/data/repository/memberinfo/MemberInfoRepositoryImp.kt
+++ b/app/src/main/java/com/pet/frompet/data/repository/memberinfo/MemberInfoRepositoryImp.kt
@@ -1,0 +1,38 @@
+package com.pet.frompet.data.repository.memberinfo
+
+import android.content.Context
+import android.util.Log
+import com.pet.frompet.R
+import com.pet.frompet.data.model.CommunityHomeData
+
+class MemberInfoRepositoryImp(
+    private val context: Context
+):MemberInfoRepository {
+    override suspend fun getMemberSpinner(): List<CommunityHomeData> {
+        val categories = listOf(
+            "category_dog", "category_cat", "category_raccoon", "category_fox",
+            "category_chick", "category_pig", "category_snake", "category_fish"
+        )
+        Log.e("sshImp", "getCategory called with categories: $categories")
+        return categories.map { categoryString ->
+            val stringResourceId = context.resources.getIdentifier(categoryString, "string", context.packageName)
+            val categoryText = if (stringResourceId != 0) {
+                context.getString(stringResourceId)
+            } else {
+                "Category Not Found"
+            }
+
+            CommunityHomeData(
+                getAnimalImage(categoryString), // 이미지 리소스 ID 가져오기
+                categoryText
+            )
+        }
+    }
+
+    private fun getAnimalImage(categoryString: String): Int {
+        val resourceName = categoryString.split("_").last()
+        val resourceIdName =
+            context.resources.getIdentifier(resourceName, "drawable", context.packageName)
+        return if (resourceIdName != 0) resourceIdName else R.drawable.frog
+    }
+}

--- a/app/src/main/java/com/pet/frompet/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/pet/frompet/ui/login/LoginViewModel.kt
@@ -118,33 +118,7 @@ class LoginViewModel @Inject constructor(
             eventsChannel.send(AllEvents.Error(error[1]))
         }
     }
-    fun deleteAccount() = viewModelScope.launch {
-        try {
-            val result = userRepository.deleteAccount()
-            if(result){
-                eventsChannel.send(AllEvents.Message("회원 탈퇴 성공"))
-            }else{
-                eventsChannel.send(AllEvents.Error("회원 탈퇴 실패"))
-            }
-        }catch (e: Exception){
-            val error = e.toString().split(":").toTypedArray()
-            eventsChannel.send(AllEvents.Error(error[1]))
-        }
-    }
 
-
-    fun signOut() = viewModelScope.launch {
-        try {
-            val user = userRepository.signOut()
-            user?.let {
-                eventsChannel.send(AllEvents.Message("로그아웃 실패"))
-            } ?: eventsChannel.send(AllEvents.Message("로그아웃 성공"))
-            getCurrentUser()
-        } catch (e: Exception) {
-            val error = e.toString().split(":").toTypedArray()
-            eventsChannel.send(AllEvents.Error(error[1]))
-        }
-    }
 
     private fun getCurrentUser() = viewModelScope.launch {
         val user = userRepository.getCurrentUser()
@@ -175,21 +149,6 @@ class LoginViewModel @Inject constructor(
         }
 
     }
-
-    private fun saveGoogle(uid: String){
-        val userDocRef = FirebaseFirestore.getInstance().collection("User").document(uid)
-        val userData = hashMapOf(
-            "username" to "Google 사용자 이름",
-            "email" to "Google 사용자 이메일"
-        )
-        userDocRef.set(userData)
-            .addOnSuccessListener {
-            }
-            .addOnFailureListener { e ->
-            }
-
-    }
-
     sealed class AllEvents {
         data class Message(val message: String) : AllEvents()
         data class ErrorCode(val code: Int) : AllEvents()
@@ -204,7 +163,6 @@ class LoginViewModel @Inject constructor(
                 }
             }
             }
-        data class GoogleSignIn(val error: Intent):AllEvents()
         }
     }
 

--- a/app/src/main/java/com/pet/frompet/ui/login/MemberInfoAdapter.kt
+++ b/app/src/main/java/com/pet/frompet/ui/login/MemberInfoAdapter.kt
@@ -11,7 +11,7 @@ import com.pet.frompet.R
 import com.pet.frompet.data.model.CommunityHomeData
 
 
-class MemberInfoAdapter(private val context: Context, private val data: List<CommunityHomeData>
+class MemberInfoAdapter(private val context: Context, private var data: List<CommunityHomeData>
 ):BaseAdapter() {
     override fun getCount(): Int {
         return data.size
@@ -39,5 +39,10 @@ class MemberInfoAdapter(private val context: Context, private val data: List<Com
 
     override fun getDropDownView(position: Int, convertView: View?, parent: ViewGroup?): View {
         return super.getDropDownView(position, convertView, parent)
+    }
+
+    fun updateData(newData: List<CommunityHomeData>){
+        data = newData
+        notifyDataSetChanged()
     }
 }

--- a/app/src/main/java/com/pet/frompet/ui/login/MemberInfoViewModel.kt
+++ b/app/src/main/java/com/pet/frompet/ui/login/MemberInfoViewModel.kt
@@ -68,11 +68,6 @@ class MemberInfoViewModel(
             }
         }
     }
-
-    fun updatePetProfileLiveData(imageUrl: String) {
-        _petProfileLiveData.value = imageUrl
-    }
-
     private fun showToast(message: String) {
         /*  Toast.makeText(this, message, Toast.LENGTH_SHORT).show()*/
     }

--- a/app/src/main/java/com/pet/frompet/ui/login/MemberInfoViewModel.kt
+++ b/app/src/main/java/com/pet/frompet/ui/login/MemberInfoViewModel.kt
@@ -1,0 +1,47 @@
+package com.pet.frompet.ui.login
+
+import android.content.Context
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.pet.frompet.data.model.CommunityHomeData
+import com.pet.frompet.data.repository.memberinfo.MemberInfoRepository
+import com.pet.frompet.data.repository.memberinfo.MemberInfoRepositoryImp
+import kotlinx.coroutines.launch
+
+class MemberInfoViewModel(
+    private val memberInfoRepository: MemberInfoRepository
+) : ViewModel() {
+
+    private val _petSpinnerType: MutableLiveData<List<CommunityHomeData>> = MutableLiveData()
+    val petSpinnerType: LiveData<List<CommunityHomeData>> = _petSpinnerType
+
+    private val _selectPetType = MutableLiveData<CommunityHomeData>()
+    val selectPetType:LiveData<CommunityHomeData> = _selectPetType
+
+
+    fun getMemberInfoSpinner() {
+        viewModelScope.launch {
+            val communityHomeData = memberInfoRepository.getMemberSpinner()
+            _petSpinnerType.postValue(communityHomeData)
+        }
+    }
+
+    fun setSelectType(item: CommunityHomeData){
+        _selectPetType.value = item
+    }
+}
+
+class MemberInfoViewModelFactory(
+    private val context: Context
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(MemberInfoViewModel::class.java)) {
+            return MemberInfoViewModel(MemberInfoRepositoryImp(context)) as T
+        } else {
+            throw IllegalArgumentException("Not found ViewModel class.")
+        }
+    }
+}

--- a/app/src/main/java/com/pet/frompet/ui/login/MemberInfoViewModel.kt
+++ b/app/src/main/java/com/pet/frompet/ui/login/MemberInfoViewModel.kt
@@ -6,7 +6,10 @@ import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
+import com.google.firebase.firestore.FirebaseFirestore
+import com.google.firebase.storage.FirebaseStorage
 import com.pet.frompet.data.model.CommunityHomeData
+import com.pet.frompet.data.model.User
 import com.pet.frompet.data.repository.memberinfo.MemberInfoRepository
 import com.pet.frompet.data.repository.memberinfo.MemberInfoRepositoryImp
 import kotlinx.coroutines.launch
@@ -19,27 +22,70 @@ class MemberInfoViewModel(
     val petSpinnerType: LiveData<List<CommunityHomeData>> = _petSpinnerType
 
     private val _selectPetType = MutableLiveData<CommunityHomeData>()
-    val selectPetType:LiveData<CommunityHomeData> = _selectPetType
+    val selectPetType: LiveData<CommunityHomeData> = _selectPetType
+
+    private val _petProfileLiveData = MutableLiveData<String>()
+    val petProfileLiveData: LiveData<String> = _petProfileLiveData
+
+    private val _saveFireStore: MutableLiveData<Result<Unit>> = MutableLiveData()
+    val saveFireStore: LiveData<Result<Unit>> = _saveFireStore
 
 
     fun getMemberInfoSpinner() {
         viewModelScope.launch {
+            try{
             val communityHomeData = memberInfoRepository.getMemberSpinner()
             _petSpinnerType.postValue(communityHomeData)
+        }catch (_: Exception){
+
+        }
+        }
+    }
+    fun saveToFireStore(user: User) {
+        viewModelScope.launch {
+            try {
+                val result = memberInfoRepository.saveToFireStore(user)
+                _saveFireStore.postValue(result)
+            } catch (e: Exception) {
+                _saveFireStore.postValue(Result.failure(e))
+            }
+        }
+    }
+    fun contentUpload(petProfile: String?) {
+        viewModelScope.launch {
+            try {
+                if (petProfile == null) {
+                    throw IllegalArgumentException("petProfile is null")
+                }
+
+                val imageUrl = memberInfoRepository.uploadPetProfile(petProfile)
+                showToast("이미지 업로드 성공")
+
+                // Set the value of the LiveData
+                _petProfileLiveData.value = imageUrl
+            } catch (e: Exception) {
+                showToast("이미지 업로드 실패: ${e.message}")
+            }
         }
     }
 
-    fun setSelectType(item: CommunityHomeData){
-        _selectPetType.value = item
+    fun updatePetProfileLiveData(imageUrl: String) {
+        _petProfileLiveData.value = imageUrl
+    }
+
+    private fun showToast(message: String) {
+        /*  Toast.makeText(this, message, Toast.LENGTH_SHORT).show()*/
     }
 }
 
 class MemberInfoViewModelFactory(
-    private val context: Context
+    private val context: Context,
+    private val storage: FirebaseStorage,
+    private val fireStore: FirebaseFirestore
 ) : ViewModelProvider.Factory {
     override fun <T : ViewModel> create(modelClass: Class<T>): T {
         if (modelClass.isAssignableFrom(MemberInfoViewModel::class.java)) {
-            return MemberInfoViewModel(MemberInfoRepositoryImp(context)) as T
+            return MemberInfoViewModel(MemberInfoRepositoryImp(context, storage,fireStore)) as T
         } else {
             throw IllegalArgumentException("Not found ViewModel class.")
         }

--- a/app/src/main/java/com/pet/frompet/ui/login/SingUpActivity.kt
+++ b/app/src/main/java/com/pet/frompet/ui/login/SingUpActivity.kt
@@ -39,13 +39,16 @@ class SingUpActivity : AppCompatActivity() {
                 val email = userEmailEtv.text.toString()
                 val password = userPasswordEtv.text.toString()
                 val confirmPass = confirmPasswordEtv.text.toString()
-                if(email.isEmpty()){
-                    Toast.makeText(this@SingUpActivity,"이메일을 입력해주세요",Toast.LENGTH_SHORT).show()
-                }else if (password.length < 6){
-                    Toast.makeText(this@SingUpActivity,"비밀번호는 6자리 이상입니다.",Toast.LENGTH_SHORT).show()
-                }else{
-                    viewModel.signUpUser(email, password, confirmPass)
+                if (isValidEmail(email)) {
+                    if (password.length < 6) {
+                        showToast("비밀번호는 6자리 이상이어야 합니다.")
+                    } else {
+                        viewModel.signUpUser(email, password, confirmPass)
+                    }
+                } else {
+                    showToast("올바른 이메일 형식이 아닙니다.")
                 }
+
 
             }
             signInTxt.setOnClickListener {
@@ -143,5 +146,9 @@ class SingUpActivity : AppCompatActivity() {
     }
     private fun showToast(message: String) {
         Toast.makeText(this@SingUpActivity, message, Toast.LENGTH_SHORT).show()
+    }
+    private fun isValidEmail(email: String): Boolean {
+        val emailRegex = Regex("^[A-Za-z](.*)([@]{1})(.{1,})(\\.)(.{1,})")
+        return emailRegex.matches(email)
     }
 }

--- a/app/src/main/java/com/pet/frompet/ui/map/MapViewModel.kt
+++ b/app/src/main/java/com/pet/frompet/ui/map/MapViewModel.kt
@@ -1,101 +1,61 @@
 package com.pet.frompet.ui.map
 
-import android.util.Log
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.google.firebase.auth.FirebaseAuth
-import com.google.firebase.database.DataSnapshot
-import com.google.firebase.database.DatabaseError
-import com.google.firebase.database.ValueEventListener
-import com.pet.frompet.data.model.UserLocation
-import com.google.firebase.database.ktx.database
+import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.firestore.FirebaseFirestore
-import com.google.firebase.ktx.Firebase
-import com.naver.maps.geometry.LatLng
+import com.pet.frompet.data.model.UserLocation
 import com.naver.maps.geometry.LatLngBounds
-import com.pet.frompet.data.model.User
+import com.pet.frompet.data.model.UserLocationInfo
+import com.pet.frompet.data.repository.map.MapRepository
+import com.pet.frompet.data.repository.map.MapRepositoryImpl
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.tasks.await
 
-class MapViewModel() : ViewModel() {
-
-    private val database = Firebase.database
-    private val firestore = FirebaseFirestore.getInstance()
-    private val locationRef = database.getReference("location")
-    private val currentUserId = FirebaseAuth.getInstance().currentUser?.uid ?: "" // 현재 uid 갖고 옴
+class MapViewModel(
+    private val mapRepository:MapRepository
+) : ViewModel() {
 
     private val _userLocationInfo = MutableLiveData<UserLocationInfo>()
     val userLocation : LiveData<UserLocationInfo> get() = _userLocationInfo
 
     private val _otherUserLocation = MutableLiveData<List<UserLocationInfo>>()
-    val otherUserLocation : MutableLiveData<List<UserLocationInfo>> get() = _otherUserLocation
-
-    // 상태 클래스 (상태패턴)
-    data class UserLocationInfo(
-        val userUid : List<String> = emptyList(),
-        val userLocations : List<UserLocation> = emptyList()
-    )
-
+    val otherUserLocation: LiveData<List<UserLocationInfo>> get() = _otherUserLocation
 
     fun getloadLocationData(bounds: LatLngBounds) {
-
-        val userUids = mutableListOf<String>()
-        val locationList = mutableListOf<UserLocation>()
-        var userLocationInfo = UserLocationInfo()
-
-        locationRef.get().addOnSuccessListener { snapshot ->
-
-            for (locationSnapshot in snapshot.children) {
-                val location =
-                    locationSnapshot.getValue(com.pet.frompet.data.model.UserLocation::class.java)
-                if (location != null && bounds.contains(
-                        LatLng(
-                            location.latitude,
-                            location.longitude
-                        )
-                    )
-                ) {
-                    Log.d("LoadLocationData", "유저 아이디: ${locationSnapshot.key}")
-                    // 지도 영역에 포함되는 위치만 처리
-                    // null 방지 위해 orEmpty()
-                    val userUid = locationSnapshot.key.orEmpty()
-                    userUids.add(userUid)
-
-                    // 위치 정보를 리스트에 추가
-                    locationList.add(UserLocation(location.latitude, location.longitude))
-                }
-            }
-            userLocationInfo = userLocationInfo.copy(userUids, locationList)
+        viewModelScope.launch {
+            val userLocationInfo = mapRepository.getloadLocationData(bounds)
             _userLocationInfo.value = userLocationInfo
         }
     }
 
     // 현재 사용자 위치 FB 업로드
     fun currentLocationUpload(latitude : Double, longitude : Double) {
-        val userLocation = UserLocation(latitude, longitude)
-        locationRef.child(currentUserId).setValue(userLocation)
-
+        viewModelScope.launch {
+            mapRepository.updateUserLocation(UserLocation(latitude, longitude))
+        }
     }
 
     // 사용자 위치 마커 표시
     fun getOtherUserLocations() {
-        locationRef.addValueEventListener(object : ValueEventListener {
-            override fun onDataChange(snapshot: DataSnapshot) {
-                val userLocationList = mutableListOf<UserLocationInfo>()
-                for (snapshots in snapshot.children) {
-                    val location = snapshots.getValue(UserLocation::class.java)
-                    val userUid = snapshots.key
-
-                    if (location != null && userUid != null && userUid != currentUserId) {
-                        userLocationList.add(UserLocationInfo(listOf(userUid), listOf(location)))
-                    }
-                }
-                _otherUserLocation.value = userLocationList
-            }
-
-            override fun onCancelled(error: DatabaseError) {}
-        })
+        viewModelScope.launch {
+            val otherUserLocations=mapRepository.getOtherUserLocation()
+            val userLocationInfoList = otherUserLocations.map{UserLocationInfo(listOf(), listOf(it))}
+            _otherUserLocation.value = userLocationInfoList
+        }
+    }
+}
+class MapViewModelFactory(
+    private val firebaseDatabase: FirebaseDatabase,
+    private val firestore: FirebaseFirestore
+) : ViewModelProvider.Factory {
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(MapViewModel::class.java)) {
+            return MapViewModel(MapRepositoryImpl(firebaseDatabase, firestore)) as T
+        } else {
+            throw IllegalArgumentException("Not found ViewModel")
+        }
     }
 }

--- a/app/src/main/java/com/pet/frompet/ui/map/NaverMapFragment.kt
+++ b/app/src/main/java/com/pet/frompet/ui/map/NaverMapFragment.kt
@@ -17,6 +17,7 @@ import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.Observer
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.lifecycleScope
 import coil.Coil
 import coil.request.ImageRequest
@@ -26,6 +27,7 @@ import com.google.android.gms.location.LocationServices
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.database.DataSnapshot
 import com.google.firebase.database.DatabaseError
+import com.google.firebase.database.FirebaseDatabase
 import com.google.firebase.database.ValueEventListener
 import com.google.firebase.database.ktx.database
 import com.google.firebase.firestore.FirebaseFirestore
@@ -54,16 +56,25 @@ import java.lang.NumberFormatException
 
 class NaverMapFragment : Fragment(), OnMapReadyCallback {
 
-    private val viewModel: MapViewModel by viewModels()
+    private val viewModel by lazy {
+        ViewModelProvider(
+            this,
+            MapViewModelFactory(firebaseDatabase, firestore)
+        ).get(MapViewModel::class.java)
+    }
 
     private lateinit var locationSource: FusedLocationSource
     private lateinit var fusedLocationClient: FusedLocationProviderClient
 
     private var naverMap: NaverMap? = null
-    private val firestore = FirebaseFirestore.getInstance()
-    private val database = Firebase.database
-    private val locationRef = database.getReference("location")
 
+    private val firebaseDatabase: FirebaseDatabase by lazy {
+        FirebaseDatabase.getInstance()
+    }
+
+    private val firestore: FirebaseFirestore by lazy {
+        FirebaseFirestore.getInstance()
+    }
     private var _binding: FragmentMapBinding? = null
     private val binding get() = _binding!!
 
@@ -151,11 +162,6 @@ class NaverMapFragment : Fragment(), OnMapReadyCallback {
     override fun onMapReady(naverMap: NaverMap) {
         this.naverMap = naverMap
         setUpMap()
-
-        // Firebase
-        val database = Firebase.database
-        val locationRef = database.getReference("location")
-
         fusedLocationClient =
             LocationServices.getFusedLocationProviderClient(requireContext()) // 초기화
         if (ActivityCompat.checkSelfPermission(
@@ -197,6 +203,7 @@ class NaverMapFragment : Fragment(), OnMapReadyCallback {
                 }
             }
         })
+        viewModel.getOtherUserLocations()
     }
 
 


### PR DESCRIPTION
1. 회원정보 입력 Activity 리포지토리 패턴을 적용했습니다
- 기존 하드 코딩 되어있던 스피너 -> 안드로이드 리소스 파일을 파싱(리포지토리 패턴 적용) -> 추가적인 동물정도에 대한 동적 대응
- 프로필 사진을 저장하는 로직 분리
- 회원 정보를 입력하고 나서 파이어 스토어에 저장하는 로직 분리
- 기존 생일을 선택할때 미래의 날짜를 선택할 수 있는 부분도 현재 기준날짜에서 과거만 선택하게 적용
- 뷰모델에서 팩토리로 UI에 매개변수로 적용

2. 맵 Fragment 리포지토리 패턴 적용했습니다.
- 기존 수진님이 작업하셨던 뷰모델을 토대로 코드 변경이 거의 없이 작업 완료
- 뷰모델에 있던 로직을 imp에서 관리하며 뷰모델에선 라이브 데이터를 통한 UI에 적용

## 트러블 슈팅
- 패턴 적용전 코드에 대한 이해도 ⬇︎ 로직 분리가 어려웠던점
- 패턴 적용 이후 코드 이해도가 없어서 다른 유저의 정보를 지도상 마커로 띄우지 못했던점
-> 수진님 코드로 인해 완료